### PR TITLE
Support translations

### DIFF
--- a/db/seeds/dev/05_categories.js
+++ b/db/seeds/dev/05_categories.js
@@ -21,5 +21,17 @@ exports.seed = function (knex) {
       });
 
       return knex("category_details").insert(categoryDetails);
+    })
+    .then(function () {
+      const idx = categoriesSeed.length;
+      return knex("category_details").insert([
+        {
+          id: idx + 1,
+          category_id: 1,
+          name: "spanish name",
+          preferred_name: "spanish preferred name",
+          lang: "es",
+        },
+      ]);
     });
 };

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,9 @@ const helmet = require("helmet");
 const database = require("./db");
 
 const CLIENT_PATH = path.join(__dirname, "../", "build");
+// Must be sorted for array agg query
+const SUPPORTED_LANGUAGES = ["en", "es"];
+const DEFAULT_LANGUAGE_INDEX = 0;
 
 i18next.use(i18nextMiddleware.LanguageDetector).init({
   supportedLngs: ["en", "es"],
@@ -26,29 +29,41 @@ app.get("/api/featured-categories", async (req, res) => {
   const categories = await database("featured_categories")
     .select(
       "categories.id",
-      "category_details.name",
-      "category_details.preferred_name"
+      database.raw(
+        "ARRAY_AGG(category_details.name ORDER BY category_details.lang) as name"
+      ),
+      database.raw(
+        "ARRAY_AGG(category_details.preferred_name ORDER BY category_details.lang) as preferred_name"
+      )
     )
     .join("categories", "categories.id", "featured_categories.category_id")
     .join("category_details", "categories.id", "category_details.category_id")
     .where({ "categories.parent_id": null })
-    .where({ "category_details.lang": req.language });
+    .groupBy("categories.id");
 
-  res.status(200).json(categories);
+  res
+    .status(200)
+    .json(translateInput(categories, req.lang, ["name", "preferred_name"]));
 });
 
 app.get("/api/categories", async (req, res) => {
   const categories = await database("categories")
     .select(
       "categories.id",
-      "category_details.name",
-      "category_details.preferred_name"
+      database.raw(
+        "ARRAY_AGG(category_details.name ORDER BY category_details.lang) as name"
+      ),
+      database.raw(
+        "ARRAY_AGG(category_details.preferred_name ORDER BY category_details.lang) as preferred_name"
+      )
     )
     .join("category_details", "categories.id", "category_details.category_id")
     .where({ "categories.parent_id": null })
-    .where({ "category_details.lang": req.language });
+    .groupBy("categories.id");
 
-  res.status(200).json(categories);
+  res
+    .status(200)
+    .json(translateInput(categories, req.lang, ["name", "preferred_name"]));
 });
 
 app.get("/api/categories/:category_id/resources", async (req, res) => {
@@ -57,12 +72,24 @@ app.get("/api/categories/:category_id/resources", async (req, res) => {
   const resources = await database("resources")
     .select(
       "resources.id",
-      "resource_details.name",
-      "resource_details.description",
-      "resource_details.phone_number",
-      "resource_details.website",
-      "resource_details.address",
-      "organization_details.name as organization",
+      database.raw(
+        "ARRAY_AGG(resource_details.name ORDER BY resource_details.lang) as name"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.description ORDER BY resource_details.lang) as description"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.phone_number ORDER BY resource_details.lang) as phone_number"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.website ORDER BY resource_details.lang) as website"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.address ORDER BY resource_details.lang) as address"
+      ),
+      database.raw(
+        "ARRAY_AGG(organization_details.name ORDER BY organization_details.lang) as organization"
+      ),
       database.raw("ARRAY_AGG(category_details.name) as subcategories")
     )
     .join("resource_details", "resources.id", "resource_details.resource_id")
@@ -81,7 +108,6 @@ app.get("/api/categories/:category_id/resources", async (req, res) => {
       "organizations.id"
     )
     .where({ "categories.parent_id": categoryId })
-    .where({ "resource_details.lang": req.language })
     .modify((queryBuilder) => {
       if (!req.query.neighborhoods) {
         return;
@@ -103,33 +129,20 @@ app.get("/api/categories/:category_id/resources", async (req, res) => {
       }
       return queryBuilder.orderBy("resource_details.updated_at", "desc");
     })
-    .groupBy(
-      "resources.id",
-      "resource_details.name",
-      "resource_details.description",
-      "resource_details.phone_number",
-      "resource_details.website",
-      "resource_details.address",
-      "resource_details.updated_at",
-      "organization_details.name"
+    .groupBy("resources.id", "resource_details.name", "resource_details.updated_at");
+
+  res
+    .status(200)
+    .json(
+      translateInput(resources, req.lang, [
+        "name",
+        "description",
+        "phone_number",
+        "website",
+        "address",
+        "organization",
+      ])
     );
-
-  res.status(200).json(resources);
-});
-
-app.get("/api/resources", async (req, res) => {
-  const resources = await database("resources")
-    .select(
-      "resources.id",
-      "resources.organization_id",
-      "resource_details.name",
-      "resource_details.description",
-      "resource_details.phone_number"
-    )
-    .join("resource_details", "resources.id", "resource_details.resource_id")
-    .where({ "resource_details.lang": req.language });
-
-  res.status(200).json(resources);
 });
 
 app.get("/api/resources/:resource_id", async (req, res) => {
@@ -138,22 +151,53 @@ app.get("/api/resources/:resource_id", async (req, res) => {
   const resource = await database("resources")
     .select(
       "resources.id",
-      "resource_details.name",
-      "resource_details.preferred_name",
-      "resource_details.description",
-      "resource_details.phone_number",
-      "resource_details.email",
-      "resource_details.address",
-      "resource_details.website",
-      "resource_details.postal_code",
-      "resource_details.latitude",
-      "resource_details.longitude",
-      "resource_details.application_process",
-      "resource_details.required_documents",
-      "resource_details.eligibility",
-      "resource_details.schedule",
+
+      database.raw(
+        "ARRAY_AGG(resource_details.name ORDER BY resource_details.lang) as name"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.preferred_name ORDER BY resource_details.lang) as preferred_name"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.description ORDER BY resource_details.lang) as description"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.phone_number ORDER BY resource_details.lang) as phone_number"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.email ORDER BY resource_details.lang) as email"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.address ORDER BY resource_details.lang) as address"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.website ORDER BY resource_details.lang) as website"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.postal_code ORDER BY resource_details.lang) as postal_code"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.latitude ORDER BY resource_details.lang) as latitude"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.longitude ORDER BY resource_details.lang) as longitude"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.application_process ORDER BY resource_details.lang) as application_process"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.required_documents ORDER BY resource_details.lang) as required_documents"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.eligibility ORDER BY resource_details.lang) as eligibility"
+      ),
+      database.raw(
+        "ARRAY_AGG(resource_details.schedule ORDER BY resource_details.lang) as schedule"
+      ),
+      database.raw(
+        "ARRAY_AGG(organization_details.name ORDER BY organization_details.lang) as organization"
+      ),
       "resource_details.updated_at",
-      "organization_details.name as organization",
       database.raw("ARRAY_AGG(category_details.name) as subcategories")
     )
     .join("resource_details", "resources.id", "resource_details.resource_id")
@@ -170,7 +214,6 @@ app.get("/api/resources/:resource_id", async (req, res) => {
       "organization_details.organization_id",
       "organizations.id"
     )
-    .where({ "resource_details.lang": req.language })
     .where({ "resources.id": resourceId })
     .groupBy(
       "resources.id",
@@ -194,16 +237,28 @@ app.get("/api/resources/:resource_id", async (req, res) => {
     )
     .first();
 
+  res
+    .status(200)
+    .json(
+      translateInput([resource], req.lang, [
+        "name",
+        "preferred_name",
+        "description",
+        "phone_number",
+        "email",
+        "address",
+        "website",
+        "postal_code",
+        "latitude",
+        "longitude",
+        "application_process",
+        "required_documents",
+        "eligibility",
+        "schedule",
+        "organization",
+      ])[0]
+    );
   res.status(200).json(resource);
-});
-
-app.get("/api/cities", async (req, res) => {
-  const cities = await database("cities")
-    .select("cities.id", "city_details.name")
-    .join("city_details", "cities.id", "city_details.city_id")
-    .where({ "city_details.lang": req.language });
-
-  res.status(200).json(cities);
 });
 
 app.get("/api/neighborhoods", async (req, res) => {
@@ -229,3 +284,33 @@ app.get("*", (_req, res) => {
 });
 
 app.listen(process.env.PORT || 5000);
+
+function translateInput(input, targetLang, keys) {
+  const targetIndex = SUPPORTED_LANGUAGES.indexOf(targetLang);
+  const defaultIndex = DEFAULT_LANGUAGE_INDEX;
+  const output = [];
+
+  input.forEach((x) => {
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+
+      if (!x[key]) {
+        continue;
+      }
+
+      if (x[key][targetIndex] && x[key][targetIndex] !== "") {
+        val = x[key][targetIndex];
+      }
+
+      if (x[key][defaultIndex]) {
+        val = x[key][defaultIndex];
+      }
+
+      x[key] = val;
+    }
+
+    output.push(x);
+  });
+
+  return output;
+}


### PR DESCRIPTION
# Support translations

## Description

Previously, if a user has selected a language with no returning translations, the site would return an empty list. However we want to default to the English translation if the specified translations doesn't exist.

To mitigate this, we now return the default translation if the specified translation doesn't exist so that the site always returns something.